### PR TITLE
fix: swap term/definition data in cards table (migration 000012)

### DIFF
--- a/db/migrations/000012_swap_card_term_definition.down.sql
+++ b/db/migrations/000012_swap_card_term_definition.down.sql
@@ -1,0 +1,1 @@
+UPDATE cards SET term = definition, definition = term;

--- a/db/migrations/000012_swap_card_term_definition.up.sql
+++ b/db/migrations/000012_swap_card_term_definition.up.sql
@@ -1,0 +1,1 @@
+UPDATE cards SET term = definition, definition = term;


### PR DESCRIPTION
Cards were entered with definition as term and term as definition due to the old question/answer column naming. This migration corrects the data so term=word/concept and definition=meaning/explanation.