### PR TITLE
Skip global rate limit in --seed (dev/test) mode

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -96,7 +96,11 @@ func main() {
 	r.Use(chimiddleware.Logger)
 	r.Use(chimiddleware.Recoverer)
 	r.Use(chimiddleware.RequestID)
-	r.Use(httprate.LimitByIP(300, time.Minute))
+	// Global IP rate limit — skipped in --seed (dev/test) mode so the e2e harness
+	// (many requests from one localhost IP) doesn't trip 429s. Prod keeps the limit.
+	if !*seedFlag {
+		r.Use(httprate.LimitByIP(300, time.Minute))
+	}
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   allowedOrigins(),
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},


### PR DESCRIPTION
The global `httprate.LimitByIP(300/min)` tripped 429s under the e2e harness (many requests from one localhost IP), causing flaky test runs. Skip it when started with `--seed`; **production (no `--seed`) keeps the limit unchanged**.

Also carried in this branch: card import accepts `term`/`definition` (falling back to `question`/`answer`).

Checks: `go vet` / `go build` / `go test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)